### PR TITLE
Added parameter colour 

### DIFF
--- a/cmd/showclock/showclock.go
+++ b/cmd/showclock/showclock.go
@@ -32,6 +32,7 @@ import (
 var clockStyle int
 var showDate bool
 var show24h bool
+var colour string
 var timeValue string
 var targetAddr string
 
@@ -52,6 +53,7 @@ func init() {
 	Cmd.Flags().IntVar(&clockStyle, "style", idot.ClockAnimatedHourGlass, "Style of clock. 0:Default 1:Christmas 2:Racing 3:Inverted 4:Hour Glass")
 	Cmd.Flags().BoolVar(&showDate, "show-date", true, "Show date as well as time")
 	Cmd.Flags().BoolVar(&show24h, "24hour", true, "Show time in 24 hour format")
+	Cmd.Flags().StringVar(&colour, "colour", "", "Set RGB colour of clock. Format: R,G,B (0-255)")
 }
 
 func doSetClock() error {
@@ -89,8 +91,8 @@ func doSetClock() error {
 		t.Minute(), t.Second()); err != nil {
 		return err
 	}
-
-	if err := device.SetClockMode(clockStyle, showDate, show24h, idot.Blue); err != nil {
+	customColour, err := idot.ColourFromString(colour)
+	if err := device.SetClockMode(clockStyle, showDate, show24h, customColour); err != nil {
 		return err
 	}
 

--- a/cmd/startserver/startserver.go
+++ b/cmd/startserver/startserver.go
@@ -61,7 +61,7 @@ func init() {
 	Cmd.Flags().StringVar(&targetAddr, "target", "", "Target iDot display MAC address")
 	Cmd.MarkFlagRequired("target")
 
-	Cmd.Flags().UintVar(&serverPort, "port", 8080, "Port to listen on")
+	Cmd.Flags().UintVar(&serverPort, "port", 8787, "Port to listen on")
 }
 
 func runServer() error {
@@ -116,6 +116,7 @@ type setClockValues struct {
 	Style    int    `json:"style,omitempty"`
 	ShowDate bool   `json:"showdate,omitempty"`
 	Show24h  bool   `json:"show24h,omitempty"`
+	Colour  string   `json:"colour,omitempty"`
 }
 
 func (ids *iDotService) handleShowClock(w http.ResponseWriter, req *http.Request) {
@@ -144,8 +145,8 @@ func (ids *iDotService) handleShowClock(w http.ResponseWriter, req *http.Request
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	if err := ids.device.SetClockMode(cv.Style, cv.ShowDate, cv.Show24h, idot.Blue); err != nil {
+	customColour, err := idot.ColourFromString(cv.Colour)
+	if err := ids.device.SetClockMode(cv.Style, cv.ShowDate, cv.Show24h, customColour); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/cmd/startserver/startserver.go
+++ b/cmd/startserver/startserver.go
@@ -61,7 +61,7 @@ func init() {
 	Cmd.Flags().StringVar(&targetAddr, "target", "", "Target iDot display MAC address")
 	Cmd.MarkFlagRequired("target")
 
-	Cmd.Flags().UintVar(&serverPort, "port", 8787, "Port to listen on")
+	Cmd.Flags().UintVar(&serverPort, "port", 8080, "Port to listen on")
 }
 
 func runServer() error {

--- a/idot/colour.go
+++ b/idot/colour.go
@@ -21,6 +21,12 @@ THE SOFTWARE.
 */
 package idot
 
+import (
+	"errors"
+    "strconv"
+    "strings"
+)
+
 type Colour struct {
 	R, G, B uint8
 }
@@ -28,3 +34,21 @@ type Colour struct {
 var Red = Colour{255, 0, 0}
 var Green = Colour{0, 255, 0}
 var Blue = Colour{0, 0, 255}
+
+
+
+func ColourFromString(rgb string) (Colour, error) {
+    parts := strings.Split(rgb, ",")
+    if len(parts) != 3 {
+        return Colour{}, ErrInvalidRGB
+    }
+    r, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+    g, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+    b, err3 := strconv.Atoi(strings.TrimSpace(parts[2]))
+    if err1 != nil || err2 != nil || err3 != nil {
+        return Colour{}, ErrInvalidRGB
+    }
+    return Colour{uint8(r), uint8(g), uint8(b)}, nil
+}
+
+var ErrInvalidRGB = errors.New("RGB inválido, use o formato 'R, G, B'")

--- a/idot/colour.go
+++ b/idot/colour.go
@@ -51,4 +51,4 @@ func ColourFromString(rgb string) (Colour, error) {
     return Colour{uint8(r), uint8(g), uint8(b)}, nil
 }
 
-var ErrInvalidRGB = errors.New("RGB inválido, use o formato 'R, G, B'")
+var ErrInvalidRGB = errors.New("Invalid RGB value. Please use the format 'R, G, B'.")


### PR DESCRIPTION
On the API server, a new parameter called **color** has been added to set the watch color using an RGB code. For example: "color": "79,25,140".

```
{
  "time"     :"",
  "style"    :4,
  "showdate" :false,
  "show24h"  :true,
  "colour"   :"79,25,140"
}
```